### PR TITLE
feat: add PendingReminders component to dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button';
 import { FolderIcon, CalendarIcon, BellIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { useProjects } from '@/hooks/usePortfolioQuery';
 import { useReminders } from '@/hooks/useReminderQuery';
+import PendingReminders from '@/components/dashboard/PendingReminders';
 import Image from 'next/image';
 
 export default function DashboardPage() {
@@ -105,6 +106,11 @@ export default function DashboardPage() {
         </motion.div>
       </div>
 
+      {/* Pending Reminders Section */}
+      <div className="mb-8">
+        <PendingReminders />
+      </div>
+
       <div className="mb-8">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold">Recent Projects</h2>
@@ -193,11 +199,10 @@ export default function DashboardPage() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
-                        className={`px-2 py-1 text-xs rounded-full ${
-                          project.featured
-                            ? 'bg-green-900 text-green-300'
-                            : 'bg-gray-700 text-gray-300'
-                        }`}
+                        className={`px-2 py-1 text-xs rounded-full ${project.featured
+                          ? 'bg-green-900 text-green-300'
+                          : 'bg-gray-700 text-gray-300'
+                          }`}
                       >
                         {project.featured ? 'Yes' : 'No'}
                       </span>
@@ -227,68 +232,6 @@ export default function DashboardPage() {
             </Link>
           </div>
         )}
-      </div>
-
-      <div>
-        <h2 className="text-2xl font-bold mb-6">Quick Actions</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <Link href="/dashboard/projects/new" className="block">
-            <div className="bg-gray-800 p-6 rounded-lg hover:bg-gray-700 transition-colors">
-              <div className="bg-indigo-600/20 p-3 rounded-lg inline-block mb-4">
-                <PlusIcon className="h-6 w-6 text-indigo-400" />
-              </div>
-              <h3 className="text-lg font-medium mb-2">Add Project</h3>
-              <p className="text-gray-400 text-sm">
-                Create a new project to showcase in your portfolio.
-              </p>
-            </div>
-          </Link>
-
-          <Link href="/dashboard/calendar" className="block">
-            <div className="bg-gray-800 p-6 rounded-lg hover:bg-gray-700 transition-colors">
-              <div className="bg-green-600/20 p-3 rounded-lg inline-block mb-4">
-                <CalendarIcon className="h-6 w-6 text-green-400" />
-              </div>
-              <h3 className="text-lg font-medium mb-2">Schedule</h3>
-              <p className="text-gray-400 text-sm">Manage your appointments and meetings.</p>
-            </div>
-          </Link>
-
-          <Link href="/dashboard/reminders" className="block">
-            <div className="bg-gray-800 p-6 rounded-lg hover:bg-gray-700 transition-colors">
-              <div className="bg-yellow-600/20 p-3 rounded-lg inline-block mb-4">
-                <BellIcon className="h-6 w-6 text-yellow-400" />
-              </div>
-              <h3 className="text-lg font-medium mb-2">Reminders</h3>
-              <p className="text-gray-400 text-sm">
-                Set reminders for important dates and deadlines.
-              </p>
-            </div>
-          </Link>
-
-          <Link href="/dashboard/integrations" className="block">
-            <div className="bg-gray-800 p-6 rounded-lg hover:bg-gray-700 transition-colors">
-              <div className="bg-purple-600/20 p-3 rounded-lg inline-block mb-4">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-6 w-6 text-purple-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-lg font-medium mb-2">Integrations</h3>
-              <p className="text-gray-400 text-sm">Connect with third-party services and tools.</p>
-            </div>
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/PendingReminders.tsx
+++ b/src/components/dashboard/PendingReminders.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { BellIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { useReminders } from '@/hooks/useReminderQuery';
+import CompactReminderItem from '@/components/reminders/CompactReminderItem';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import Link from 'next/link';
+
+export default function PendingReminders() {
+  // Fetch all incomplete reminders
+  const { data: reminders, isLoading } = useReminders({ completed: false });
+
+  // Sort reminders by due date (closest first)
+  const pendingReminders = useMemo(() => {
+    if (!reminders) return [];
+
+    return reminders
+      .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
+  }, [reminders]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold">Lembretes pendentes</h2>
+          <div className="bg-yellow-600/20 p-2 rounded-lg">
+            <BellIcon className="h-6 w-6 text-yellow-400" />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-gray-800/50 rounded-lg p-3 border border-gray-700">
+              <div className="flex items-start space-x-3">
+                <Skeleton className="h-5 w-5 rounded-full" />
+                <div className="flex-1">
+                  <Skeleton className="h-5 w-40 mb-2" />
+                  <div className="flex gap-2">
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="h-4 w-12" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="bg-gray-800 rounded-lg p-6 border border-gray-700"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Lembretes pendentes</h2>
+        <div className="bg-yellow-600/20 p-2 rounded-lg">
+          <BellIcon className="h-6 w-6 text-yellow-400" />
+        </div>
+      </div>
+
+      {pendingReminders.length > 0 ? (
+        <>
+          <div className="space-y-2 mb-4 max-h-[300px] overflow-y-auto pr-1">
+            {pendingReminders.map((reminder, index) => (
+              <CompactReminderItem
+                key={reminder.id}
+                reminder={reminder}
+                index={index}
+              />
+            ))}
+          </div>
+
+          <Link href="/dashboard/reminders">
+            <Button variant="outline" size="sm" className="w-full flex items-center justify-center gap-1">
+              <span>Ver todos</span>
+              <ArrowRightIcon className="h-4 w-4" />
+            </Button>
+          </Link>
+        </>
+      ) : (
+        <div className="text-center py-6">
+          <p className="text-gray-400 mb-4">Nenhum lembrete pendente</p>
+          <Link href="/dashboard/reminders">
+            <Button variant="outline" size="sm">
+              Gerenciar lembretes
+            </Button>
+          </Link>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/reminders/CompactReminderItem.tsx
+++ b/src/components/reminders/CompactReminderItem.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CheckCircleIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon as CheckCircleSolidIcon } from '@heroicons/react/24/solid';
+import { Reminder, REMINDER_CATEGORIES, REMINDER_PRIORITIES } from '@/types/reminder';
+import { useToggleReminder } from '@/hooks/useReminderQuery';
+import { Badge } from '@/components/ui/badge';
+import Link from 'next/link';
+
+interface CompactReminderItemProps {
+  reminder: Reminder;
+  index: number;
+}
+
+export default function CompactReminderItem({ reminder, index }: CompactReminderItemProps) {
+  const toggleReminder = useToggleReminder();
+  
+  const categoryInfo =
+    REMINDER_CATEGORIES.find((cat) => cat.value === reminder.category) || REMINDER_CATEGORIES[0];
+  const priorityInfo =
+    REMINDER_PRIORITIES.find((pri) => pri.value === reminder.priority) || REMINDER_PRIORITIES[1];
+
+  const isOverdue = !reminder.completed && new Date(reminder.dueDate) < new Date();
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleReminder.mutate(reminder.id);
+  };
+
+  return (
+    <Link href={`/dashboard/reminders?id=${reminder.id}`}>
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.2, delay: index * 0.05 }}
+        className={`bg-gray-800/50 hover:bg-gray-800 rounded-lg p-3 mb-2 border ${
+          reminder.completed
+            ? 'border-gray-700 opacity-75'
+            : isOverdue
+              ? 'border-red-700'
+              : 'border-gray-700'
+        } transition-colors`}
+      >
+        <div className="flex items-start gap-3">
+          <button
+            onClick={handleToggle}
+            className="mt-0.5 flex-shrink-0 focus:outline-none"
+            aria-label={reminder.completed ? 'Mark as incomplete' : 'Mark as complete'}
+          >
+            {reminder.completed ? (
+              <CheckCircleSolidIcon className="h-5 w-5 text-green-500" />
+            ) : (
+              <CheckCircleIcon className="h-5 w-5 text-gray-400" />
+            )}
+          </button>
+          
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between">
+              <h3 
+                className={`font-medium truncate ${
+                  reminder.completed ? 'line-through text-gray-400' : ''
+                }`}
+              >
+                {reminder.title}
+              </h3>
+            </div>
+            
+            <div className="flex flex-wrap items-center mt-1 gap-2">
+              <Badge
+                variant="outline"
+                className="text-xs"
+                style={{
+                  borderColor: priorityInfo.color,
+                  color: priorityInfo.color,
+                }}
+              >
+                {priorityInfo.label}
+              </Badge>
+
+              <span
+                className={`text-xs ${isOverdue && !reminder.completed ? 'text-red-400' : 'text-gray-400'}`}
+              >
+                {format(new Date(reminder.dueDate), "HH:mm", { locale: ptBR })}
+              </span>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </Link>
+  );
+}

--- a/tasks.md
+++ b/tasks.md
@@ -153,6 +153,7 @@
 - [x] Integrar notificações com Resend (email) e Evolution API (WhatsApp)
 - [x] Adicionar opções de configuração para escolher canais de notificação por lembrete
 - [x] Implementar visualização de lembretes no dashboard
+- [x] Adicionar seção "Lembretes pendentes" no dashboard para visualização rápida
 
 ### Calendar System (Fase 2 - Prioridade Média)
 


### PR DESCRIPTION
- Implements a `PendingReminders` component to display a list of upcoming, incomplete reminders on the dashboard.
- The component fetches reminders using `useReminders` hook, sorts them by due date, and displays them in a compact format using the new `CompactReminderItem` component.
- Adds `CompactReminderItem` component to display a single reminder with its title, priority, and due time. It also includes a toggle button to mark the reminder as complete/incomplete.
- Includes loading state with skeletons for a better user experience.
- Adds a link to the reminders page for managing all reminders.
- Removes the "Quick Actions" section from the dashboard.